### PR TITLE
refactor: Dockerfile for improved Prisma Client generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,13 @@ RUN npm install -g pnpm
 # Install dependencies
 RUN pnpm install --frozen-lockfile
 
-# Generate Prisma Client (의존성 설치 후 반드시 실행)
+# prisma 폴더를 먼저 복사
+COPY prisma ./prisma
+
+# Prisma Client 생성
 RUN pnpm prisma generate
 
-# Copy the rest of the application code
+# 나머지 소스 복사
 COPY . .
 
 # Build the app


### PR DESCRIPTION
Update the Dockerfile to copy the Prisma folder before generating the Prisma Client, enhancing the build process efficiency.

---

Dockerfile을 수정하여 prisma 폴더를 먼저 복사한 뒤, pnpm prisma generate를 실행하도록 변경했습니다.
이제 Docker 빌드 시 schema.prisma 파일을 정상적으로 인식할 수 있습니다.

이제 다시 Docker 빌드를 시도해보세요.