### PR TITLE
refactor: Dockerfile for improved build efficiency and clarity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,36 @@
-# Use an official Node.js runtime as a parent image
-FROM node:20-alpine
+# Stage 1: Build Image
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Copy all files at once to use Docker's caching efficiently
+COPY package.json pnpm-lock.yaml ./
+COPY prisma ./prisma
+COPY . .
+
+# Install dependencies including devDependencies for build process
+RUN npm install -g pnpm && pnpm install --frozen-lockfile
+
+# Generate Prisma Client (now that files are copied)
+RUN pnpm prisma generate
+
+# Build the application
+RUN pnpm run build
+
+# Stage 2: Production Image
+FROM node:20-alpine AS production
 
 # Set working directory
 WORKDIR /app
 
-# Copy package.json and lock file
-COPY package.json pnpm-lock.yaml ./
+# Copy only production-relevant files from the builder stage
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
 
-# Install pnpm
-RUN npm install -g pnpm
-
-# Install dependencies
-RUN pnpm install --frozen-lockfile
-
-# prisma 폴더를 먼저 복사
-COPY prisma ./prisma
-
-# Prisma Client 생성
-RUN pnpm prisma generate
-
-# 나머지 소스 복사
-COPY . .
-
-# Build the app
-RUN pnpm run build
-
-# Expose port 8080
+# Expose the application port
 EXPOSE 8080
 
-# Start the app
-CMD ["pnpm", "run", "start:prod"]
+# Run the production app
+CMD ["node", "dist/main"]


### PR DESCRIPTION
Reorganize the Dockerfile to enhance build efficiency by separating the build and production stages, optimizing file copying, and ensuring only necessary files are included in the final image.

---

```
# Stage 1: Build Image
FROM node:20-alpine AS builder

WORKDIR /app

# Copy all files at once to use Docker's caching efficiently
COPY package.json pnpm-lock.yaml ./
COPY prisma ./prisma
COPY . .

# Install dependencies including devDependencies for build process
RUN npm install -g pnpm && pnpm install --frozen-lockfile

# Generate Prisma Client (now that files are copied)
RUN pnpm prisma generate

# Build the application
RUN pnpm run build

---

# Stage 2: Production Image
FROM node:20-alpine AS production

# Set working directory
WORKDIR /app

# Copy only production-relevant files from the builder stage
COPY --from=builder /app/package.json ./package.json
COPY --from=builder /app/pnpm-lock.yaml ./pnpm-lock.yaml
COPY --from=builder /app/dist ./dist
COPY --from=builder /app/node_modules ./node_modules

# Expose the application port
EXPOSE 8080

# Run the production app
CMD ["node", "dist/main"]
```

---

이 Dockerfile은 두 단계로 나누어, 빌드에 필요한 모든 의존성을 첫 번째 builder 단계에서 처리하고, 최종 production 단계에서는 실행에 필요한 최소한의 파일만 복사하여 이미지 크기를 대폭 줄입니다. 이 방식이 더 안정적이고 효율적인 방법입니다.