### PR TITLE
fix: Ensure Prisma Client generation in production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,10 @@ WORKDIR /app
 # Copy only production-related files from the builder stage
 # This keeps the final image small
 COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/dist ./dist
-# pnpm은 별도로 설치하거나, --prod 옵션으로 의존성을 설치해야 합니다.
-# pnpm은 node_modules를 복사하는 대신 캐시를 활용하는 것이 더 효율적입니다.
 RUN npm install -g pnpm && pnpm install --prod
+RUN pnpm prisma generate
 
 # Expose the port the app runs on
 EXPOSE 8080


### PR DESCRIPTION
Copy the Prisma folder to the production image to ensure the Prisma Client is generated correctly during the build process.

---

<img width="1562" height="650" alt="image" src="https://github.com/user-attachments/assets/8119f8c0-f5b2-4bac-83a5-d9567d689baa" />
